### PR TITLE
Resolve type argument confusion

### DIFF
--- a/Ideas.md
+++ b/Ideas.md
@@ -1,3 +1,4 @@
+* Make sure we can publish with both Java 8 and 17
 * JSON benchmarks at https://github.com/fabienrenaud/java-json-benchmark/blob/master/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamDeserializer.java
 * Add tests for builder with _just_ an intializer, or _just_ a finalizer.
 * Can we generate a lift signature from a combine signature? Should be possible. Definitely for the simplified ones.

--- a/Ideas.md
+++ b/Ideas.md
@@ -1,13 +1,6 @@
 * JSON benchmarks at https://github.com/fabienrenaud/java-json-benchmark/blob/master/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamDeserializer.java
 * Add tests for builder with _just_ an intializer, or _just_ a finalizer.
 * Can we generate a lift signature from a combine signature? Should be possible. Definitely for the simplified ones.
-* Explicit type arguments to method call are not `TypeArgument` (for a data type). They can't specify variance. Used in generators.
-* Fix
-  ```
-  default This withType(GenericType type) {
-  return withType(FullyQualifiedName.of(type.getName().raw()));
-  }
-  ```
 * Support for static methods
 * Use processor (perhaps older version, to prevent circular dependencies) to generate `Validated` methods.
 * Test deconstructor (and other things too) when using a constructor or deconstructor of a generic type like Tuple3.

--- a/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/ContravariantGenerator.java
+++ b/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/ContravariantGenerator.java
@@ -161,7 +161,7 @@ public class ContravariantGenerator extends Generator<ContravariantGenerator> {
 
                     @Override
                     public List<String> getAdditionalArgumentsToPassToCombineMethod() {
-                        return singletonList(methodReference().withType(returnTypeConstructorArgument.asType()).withMethodName(DECOMPOSITION_DECOMPOSE_METHOD_NAME).generate());
+                        return singletonList(methodReference().withType(returnTypeConstructorArgument).withMethodName(DECOMPOSITION_DECOMPOSE_METHOD_NAME).generate());
                     }
                 }
         );
@@ -198,7 +198,7 @@ public class ContravariantGenerator extends Generator<ContravariantGenerator> {
             }
 
             @Override
-            public List<TypeArgument> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity) {
+            public List<Type> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity) {
                 return emptyList();
             }
 

--- a/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/CovariantGenerator.java
+++ b/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/CovariantGenerator.java
@@ -4,7 +4,6 @@ import nl.wernerdegroot.applicatives.processor.domain.FullyQualifiedName;
 import nl.wernerdegroot.applicatives.processor.domain.Parameter;
 import nl.wernerdegroot.applicatives.processor.domain.TypeParameter;
 import nl.wernerdegroot.applicatives.processor.domain.type.Type;
-import nl.wernerdegroot.applicatives.processor.domain.type.TypeArgument;
 import nl.wernerdegroot.applicatives.processor.domain.typeconstructor.TypeConstructor;
 
 import java.util.ArrayList;
@@ -169,11 +168,11 @@ public class CovariantGenerator extends Generator<CovariantGenerator> {
             }
 
             @Override
-            public List<TypeArgument> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity) {
+            public List<Type> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity) {
                 return asList(
-                        getCovariantTupleTypeOfArity(arity - 1).invariant(),
-                        parameterTypeConstructorArguments.get(arity - 1).asType().invariant(),
-                        getCovariantTupleTypeOfArity(arity).invariant()
+                        getCovariantTupleTypeOfArity(arity - 1),
+                        parameterTypeConstructorArguments.get(arity - 1).asType(),
+                        getCovariantTupleTypeOfArity(arity)
                 );
             }
 

--- a/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/Generator.java
+++ b/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/Generator.java
@@ -248,8 +248,8 @@ public abstract class Generator<This> {
                     .withArguments(
                             methodCall()
                                     .withType(getFullyQualifiedClassNameOfTupleClass())
-                                    .withTypeArguments(takeParameterTypeConstructorArgumentsAsTypeArguments(arity - 1))
-                                    .withTypeArguments(getClassTypeParametersAsTypeArguments())
+                                    .withTypeArguments(takeParameterTypeConstructorArgumentsAsTypes(arity - 1))
+                                    .withTypeArguments(getClassTypeParametersAsTypes())
                                     .withMethodName(TUPLE_METHOD_NAME)
                                     .withArguments(THIS)
                                     .withArguments(takeInputParameterNames(arity - 1))
@@ -291,8 +291,8 @@ public abstract class Generator<This> {
                     arity,
                     methodCall()
                             .withObjectPath(THIS)
-                            .withTypeArguments(takeParameterTypeConstructorArgumentsAsTypeArguments(arity))
-                            .withTypeArguments(returnTypeConstructorArgument.asType().invariant())
+                            .withTypeArguments(takeParameterTypeConstructorArgumentsAsTypes(arity))
+                            .withTypeArguments(returnTypeConstructorArgument.asType())
                             .withMethodName(combineMethodToGenerate)
                             .withArguments(takeInputParameterNames(arity))
                             .withArguments(getAdditionalArgumentsToPassToCombineMethod())
@@ -459,7 +459,7 @@ public abstract class Generator<This> {
 
         public abstract List<Parameter> getAdditionalTupleMethodParametersToPassOnToTupleMethod(int arity);
 
-        public abstract List<TypeArgument> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity);
+        public abstract List<Type> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity);
 
         public abstract List<String> getAdditionalArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity);
 
@@ -499,8 +499,8 @@ public abstract class Generator<This> {
                             .withArguments(
                                     methodCall()
                                             .withType(getFullyQualifiedClassNameOfTupleClass())
-                                            .withTypeArguments(takeParameterTypeConstructorArgumentsAsTypeArguments(arity - 1))
-                                            .withTypeArguments(getClassTypeParametersAsTypeArguments())
+                                            .withTypeArguments(takeParameterTypeConstructorArgumentsAsTypes(arity - 1))
+                                            .withTypeArguments(getClassTypeParametersAsTypes())
                                             .withMethodName(TUPLE_METHOD_NAME)
                                             .withArguments(selfParameterName)
                                             .withArguments(takeInputParameterNames(arity - 1))
@@ -560,6 +560,13 @@ public abstract class Generator<This> {
 
     protected FullyQualifiedName getFullyQualifiedClassNameOfTupleClass() {
         return getFullyQualifiedClassNameToGenerate().withClassName(TUPLE_CLASS_NAME);
+    }
+
+    protected List<Type> getClassTypeParametersAsTypes() {
+        return classTypeParameters
+                .stream()
+                .map(TypeParameter::asType)
+                .collect(toList());
     }
 
     protected List<TypeArgument> getClassTypeParametersAsTypeArguments() {

--- a/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/InvariantGenerator.java
+++ b/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/InvariantGenerator.java
@@ -259,12 +259,12 @@ public class InvariantGenerator extends Generator<InvariantGenerator> {
             }
 
             @Override
-            public List<TypeArgument> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity) {
+            public List<Type> getTypeArgumentsToPassOnToAccumulatorMethodForTupleMethod(int arity) {
                 return asList(
-                        getCovariantTupleTypeOfArity(arity - 1).invariant(),
-                        parameterTypeConstructorArguments.get(arity - 1).asType().invariant(),
-                        getCovariantTupleTypeOfArity(arity).invariant(),
-                        getCovariantTupleTypeOfArity(arity).invariant()
+                        getCovariantTupleTypeOfArity(arity - 1),
+                        parameterTypeConstructorArguments.get(arity - 1).asType(),
+                        getCovariantTupleTypeOfArity(arity),
+                        getCovariantTupleTypeOfArity(arity)
                 );
             }
 

--- a/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/MethodCallGenerator.java
+++ b/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/MethodCallGenerator.java
@@ -1,6 +1,6 @@
 package nl.wernerdegroot.applicatives.processor.generator;
 
-import nl.wernerdegroot.applicatives.processor.domain.type.TypeArgument;
+import nl.wernerdegroot.applicatives.processor.domain.type.Type;
 import nl.wernerdegroot.applicatives.processor.generator.ObjectPathOrTypeGenerator.HasObjectPathOrTypeGenerator;
 
 import java.util.ArrayList;
@@ -13,7 +13,7 @@ import static nl.wernerdegroot.applicatives.processor.generator.Constants.*;
 public class MethodCallGenerator implements HasObjectPathOrTypeGenerator<MethodCallGenerator> {
 
     private ObjectPathOrTypeGenerator objectPathOrTypeGenerator = new ObjectPathOrTypeGenerator();
-    private List<TypeArgument> typeArguments = new ArrayList<>();
+    private List<Type> typeArguments = new ArrayList<>();
     private String methodName;
     private List<String> arguments = new ArrayList<>();
 
@@ -31,12 +31,12 @@ public class MethodCallGenerator implements HasObjectPathOrTypeGenerator<MethodC
         return this;
     }
 
-    public MethodCallGenerator withTypeArguments(List<TypeArgument> typeArguments) {
+    public MethodCallGenerator withTypeArguments(List<Type> typeArguments) {
         this.typeArguments.addAll(typeArguments);
         return this;
     }
 
-    public MethodCallGenerator withTypeArguments(TypeArgument... typeArguments) {
+    public MethodCallGenerator withTypeArguments(Type... typeArguments) {
         return withTypeArguments(asList(typeArguments));
     }
 
@@ -62,7 +62,7 @@ public class MethodCallGenerator implements HasObjectPathOrTypeGenerator<MethodC
         if (typeArguments.isEmpty()) {
             return "";
         } else {
-            return typeArguments.stream().map(TypeArgumentGenerator::generateFrom).collect(joining(SEPARATOR, OPEN_ANGULAR_BRACKET, CLOSE_ANGULAR_BRACKET));
+            return typeArguments.stream().map(TypeGenerator::generateFrom).collect(joining(SEPARATOR, OPEN_ANGULAR_BRACKET, CLOSE_ANGULAR_BRACKET));
         }
     }
 }

--- a/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/ObjectPathOrTypeGenerator.java
+++ b/processor/src/main/java/nl/wernerdegroot/applicatives/processor/generator/ObjectPathOrTypeGenerator.java
@@ -1,6 +1,8 @@
 package nl.wernerdegroot.applicatives.processor.generator;
 
 import nl.wernerdegroot.applicatives.processor.domain.FullyQualifiedName;
+import nl.wernerdegroot.applicatives.processor.domain.TypeParameter;
+import nl.wernerdegroot.applicatives.processor.domain.TypeParameterName;
 import nl.wernerdegroot.applicatives.processor.domain.type.ConcreteType;
 import nl.wernerdegroot.applicatives.processor.domain.type.GenericType;
 import nl.wernerdegroot.applicatives.processor.generator.ObjectPathGenerator.HasObjectPathGenerator;
@@ -9,13 +11,18 @@ import java.util.Optional;
 
 public class ObjectPathOrTypeGenerator {
 
-    private Optional<FullyQualifiedName> optionalType = Optional.empty();
+    private Optional<FullyQualifiedName> optionalConcreteType = Optional.empty();
+    private Optional<TypeParameterName> optionalGenericType = Optional.empty();
     private Optional<ObjectPathGenerator> optionalObjectPathGenerator = Optional.empty();
 
     public String generate() {
         Optional<String> optionalObjectPathAsString = optionalObjectPathGenerator.map(ObjectPathGenerator::generate);
-        Optional<String> optionalTypeAsString = optionalType.map(FullyQualifiedName::raw);
-        return optionalObjectPathAsString.map(Optional::of).orElse(optionalTypeAsString).orElseThrow(NullPointerException::new);
+        Optional<String> optionalConcreteTypeAsString = optionalConcreteType.map(FullyQualifiedName::raw);
+        Optional<String> optionalGenericTypeAsString = optionalGenericType.map(TypeParameterName::raw);
+        return optionalObjectPathAsString
+                .map(Optional::of).orElse(optionalConcreteTypeAsString)
+                .map(Optional::of).orElse(optionalGenericTypeAsString)
+                .orElseThrow(NullPointerException::new);
     }
 
     public interface HasObjectPathOrTypeGenerator<This> extends HasObjectPathGenerator<This> {
@@ -30,7 +37,12 @@ public class ObjectPathOrTypeGenerator {
         }
 
         default This withType(FullyQualifiedName type) {
-            getObjectPathOrTypeGenerator().optionalType = Optional.of(type);
+            getObjectPathOrTypeGenerator().optionalConcreteType = Optional.of(type);
+            return getThis();
+        }
+
+        default This withType(TypeParameterName type) {
+            getObjectPathOrTypeGenerator().optionalGenericType = Optional.of(type);
             return getThis();
         }
 
@@ -39,7 +51,11 @@ public class ObjectPathOrTypeGenerator {
         }
 
         default This withType(GenericType type) {
-            return withType(FullyQualifiedName.of(type.getName().raw()));
+            return withType(type.getName());
+        }
+
+        default This withType(TypeParameter type) {
+            return withType(type.getName());
         }
     }
 }

--- a/processor/src/test/java/nl/wernerdegroot/applicatives/processor/generator/MethodCallGeneratorTest.java
+++ b/processor/src/test/java/nl/wernerdegroot/applicatives/processor/generator/MethodCallGeneratorTest.java
@@ -13,7 +13,7 @@ public class MethodCallGeneratorTest {
     public void givenInstanceMethodAndExplicitTypeArguments() {
         String toVerify = methodCall()
                 .withObjectPath("objects")
-                .withTypeArguments(CHAR_SEQUENCE.invariant())
+                .withTypeArguments(CHAR_SEQUENCE)
                 .withMethodName("map")
                 .withArguments("java.lang.Object::toString")
                 .generate();

--- a/processor/src/test/java/nl/wernerdegroot/applicatives/processor/generator/ObjectPathOrTypeGeneratorTest.java
+++ b/processor/src/test/java/nl/wernerdegroot/applicatives/processor/generator/ObjectPathOrTypeGeneratorTest.java
@@ -1,11 +1,16 @@
 package nl.wernerdegroot.applicatives.processor.generator;
 
+import nl.wernerdegroot.applicatives.processor.domain.TypeParameter;
+import nl.wernerdegroot.applicatives.processor.domain.TypeParameterName;
 import org.junit.jupiter.api.Test;
 
 import static nl.wernerdegroot.applicatives.processor.domain.type.Type.BIG_DECIMAL;
+import static nl.wernerdegroot.applicatives.processor.domain.type.Type.COMPARABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ObjectPathOrTypeGeneratorTest {
+
+    public static final TypeParameterName T = TypeParameterName.of("T");
 
     @Test
     public void givenObjectPath() {
@@ -22,13 +27,61 @@ public class ObjectPathOrTypeGeneratorTest {
     }
 
     @Test
-    public void givenType() {
+    public void givenConcreteType() {
         String toVerify = toTest()
                 .withType(BIG_DECIMAL)
                 .getObjectPathOrTypeGenerator()
                 .generate();
 
         String expected = "java.math.BigDecimal";
+
+        assertEquals(expected, toVerify);
+    }
+
+    @Test
+    public void givenFullyQualifiedName() {
+        String toVerify = toTest()
+                .withType(BIG_DECIMAL.getFullyQualifiedName())
+                .getObjectPathOrTypeGenerator()
+                .generate();
+
+        String expected = "java.math.BigDecimal";
+
+        assertEquals(expected, toVerify);
+    }
+
+    @Test
+    public void givenTypeParameterName() {
+        String toVerify = toTest()
+                .withType(T)
+                .getObjectPathOrTypeGenerator()
+                .generate();
+
+        String expected = "T";
+
+        assertEquals(expected, toVerify);
+    }
+
+    @Test
+    public void givenTypeParameter() {
+        String toVerify = toTest()
+                .withType(T.extending(COMPARABLE.with(T)))
+                .getObjectPathOrTypeGenerator()
+                .generate();
+
+        String expected = "T";
+
+        assertEquals(expected, toVerify);
+    }
+
+    @Test
+    public void givenGenericType() {
+        String toVerify = toTest()
+                .withType(T.asType())
+                .getObjectPathOrTypeGenerator()
+                .generate();
+
+        String expected = "T";
 
         assertEquals(expected, toVerify);
     }


### PR DESCRIPTION
The type arguments to a method (types without `extends` or `super`) are different from type arguments to classes (like `List<? extends Animal>` that _do_ allow for `extends` or `super`). This PR makes sure both are treated correctly.